### PR TITLE
Add ability to receive settings via serial

### DIFF
--- a/puara.cpp
+++ b/puara.cpp
@@ -82,6 +82,9 @@ int Puara::serial_data_length;
 std::string Puara::serial_data_str;
 std::string Puara::serial_data_str_buffer;
 
+const std::string Puara::data_start = "<<<";
+const std::string Puara::data_end = ">>>";
+
 
 unsigned int Puara::get_version() {
     return version;
@@ -1235,7 +1238,7 @@ void Puara::interpret_serial(void *pvParameters) {
             }
             std::ifstream in("/spiffs/config.json");
             std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
-            std::cout << contents << std::endl;
+            std::cout << Puara::data_start << contents << Puara::data_end << std::endl;
             fclose(f);
             Puara::unmount_spiffs();
         } else if (serial_data_str.rfind("sendsettings", 0) == 0) {
@@ -1252,7 +1255,7 @@ void Puara::interpret_serial(void *pvParameters) {
             }
             std::ifstream in("/spiffs/settings.json");
             std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
-            std::cout << contents << std::endl;
+            std::cout << Puara::data_start << contents << Puara::data_end << std::endl;
             fclose(f);
             Puara::unmount_spiffs();
         } else {

--- a/puara.cpp
+++ b/puara.cpp
@@ -502,12 +502,17 @@ void Puara::read_settings_json_internal(std::string& contents) {
     settings = cJSON_GetObjectItemCaseSensitive(root, "settings");
    
     settingsVariables temp;
-    variables.clear();
+    if (!merge) {
+        variables.clear();
+    }
     std::cout << "json: Extract info" << std::endl;
     cJSON_ArrayForEach(setting, settings) {
         cJSON *name = cJSON_GetObjectItemCaseSensitive(setting, "name");
         cJSON *value = cJSON_GetObjectItemCaseSensitive(setting, "value");
         temp.name = name->valuestring;
+        if (variables_fields.find(temp.name) == variables_fields.end()) {
+            continue;
+        }
         if (variables_fields.find(temp.name) == variables_fields.end()) {
             variables_fields.insert({temp.name, variables.size()});
         }
@@ -1221,8 +1226,8 @@ void Puara::interpret_serial(void *pvParameters) {
             Puara::write_config_json();
         } else if (serial_data_str.rfind("settings", 0) == 0) {
             serial_data_str_buffer = serial_data_str.substr(serial_data_str.find(" ")+1);
-            Puara::read_settings_json_internal(serial_data_str_buffer);
-            Puara::write_settings_json();
+            Puara::read_settings_json_internal(serial_data_str_buffer, true);
+            // Puara::write_settings_json();
         } else if (serial_data_str.compare("getconfig") == 0) {
             Puara::mount_spiffs();
             FILE* f = fopen("/spiffs/config.json", "r");

--- a/puara.cpp
+++ b/puara.cpp
@@ -1224,7 +1224,7 @@ void Puara::interpret_serial(void *pvParameters) {
             Puara::read_config_json_internal(serial_data_str_buffer);
         } else if (serial_data_str.rfind("writeconfig") == 0) {
             Puara::write_config_json();
-        } else if (serial_data_str.compare("getconfig") == 0) {
+        } else if (serial_data_str.compare("readconfig") == 0) {
             Puara::mount_spiffs();
             FILE* f = fopen("/spiffs/config.json", "r");
             if (f == NULL) {
@@ -1241,7 +1241,7 @@ void Puara::interpret_serial(void *pvParameters) {
             Puara::read_settings_json_internal(serial_data_str_buffer, true);
         } else if (serial_data_str.rfind("writesettings") == 0) {
             Puara::write_settings_json();
-        } else if (serial_data_str.compare("getsettings") == 0) {
+        } else if (serial_data_str.compare("readsettings") == 0) {
             Puara::mount_spiffs();
             FILE* f = fopen("/spiffs/settings.json", "r");
             if (f == NULL) {

--- a/puara.cpp
+++ b/puara.cpp
@@ -1210,6 +1210,10 @@ std::string Puara::convertToString(char* a) {
     return s;
 }
 
+void Puara::send_serial_data(std::string data) {
+    std::cout << Puara::data_start << data << Puara::data_end << std::endl;
+}
+
 void Puara::interpret_serial(void *pvParameters) {
     while (1) {
         vTaskDelay(1000 / portTICK_RATE_MS);
@@ -1223,7 +1227,7 @@ void Puara::interpret_serial(void *pvParameters) {
         } else if (serial_data_str.compare("ping") == 0) {
             std::cout << "pong\n";
         } else if (serial_data_str.compare("whatareyou") == 0) {
-            std::cout << Puara::data_start << Puara::dmiName << Puara::data_end << std::endl;
+            Puara::send_serial_data(Puara::dmiName);
         } else if (serial_data_str.rfind("sendconfig", 0) == 0) {
             serial_data_str_buffer = serial_data_str.substr(serial_data_str.find(" ")+1);
             Puara::read_config_json_internal(serial_data_str_buffer);
@@ -1238,7 +1242,7 @@ void Puara::interpret_serial(void *pvParameters) {
             }
             std::ifstream in("/spiffs/config.json");
             std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
-            std::cout << Puara::data_start << contents << Puara::data_end << std::endl;
+            Puara::send_serial_data(contents);
             fclose(f);
             Puara::unmount_spiffs();
         } else if (serial_data_str.rfind("sendsettings", 0) == 0) {
@@ -1255,7 +1259,7 @@ void Puara::interpret_serial(void *pvParameters) {
             }
             std::ifstream in("/spiffs/settings.json");
             std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
-            std::cout << Puara::data_start << contents << Puara::data_end << std::endl;
+            Puara::send_serial_data(contents);
             fclose(f);
             Puara::unmount_spiffs();
         } else {

--- a/puara.cpp
+++ b/puara.cpp
@@ -489,8 +489,7 @@ void Puara::read_settings_json() {
     Puara::unmount_spiffs();
 }
 
-void Puara::read_settings_json_internal(std::string& contents)
-{
+void Puara::read_settings_json_internal(std::string& contents) {
     std::cout << "json: Getting data" << std::endl;
     cJSON *root = cJSON_Parse(contents.c_str());
     cJSON *setting = NULL;

--- a/puara.cpp
+++ b/puara.cpp
@@ -20,8 +20,6 @@ std::string Puara::device;
 unsigned int Puara::id;
 std::string Puara::author;
 std::string Puara::institution;
-
-
 std::string Puara::APpasswd;
 std::string Puara::APpasswdVal1;
 std::string Puara::APpasswdVal2;

--- a/puara.cpp
+++ b/puara.cpp
@@ -1219,9 +1219,11 @@ void Puara::interpret_serial(void *pvParameters) {
         } else if (serial_data_str.rfind("config", 0) == 0) {
             serial_data_str_buffer = serial_data_str.substr(serial_data_str.find(" ")+1);
             Puara::read_config_json_internal(serial_data_str_buffer);
+            Puara::write_config_json();
         } else if (serial_data_str.rfind("settings", 0) == 0) {
             serial_data_str_buffer = serial_data_str.substr(serial_data_str.find(" ")+1);
             Puara::read_settings_json_internal(serial_data_str_buffer);
+            Puara::write_settings_json();
         } else {
             std::cout << "\nI don´t recognize the command \"" << serial_data_str << "\""<< std::endl;
         }
@@ -1264,7 +1266,7 @@ void Puara::interpret_serial(void *pvParameters) {
     bool Puara::start_serial_listening() {
         //std::cout << "starting serial monitor \n";
         xTaskCreate(serial_monitor, "serial_monitor", 2048, NULL, 10, NULL);
-        xTaskCreate(interpret_serial, "interpret_serial", 2048, NULL, 10, NULL);
+        xTaskCreate(interpret_serial, "interpret_serial", 4096, NULL, 10, NULL);
         return 1;
     }
 

--- a/puara.cpp
+++ b/puara.cpp
@@ -481,7 +481,8 @@ void Puara::read_settings_json() {
 
     std::cout << "json: Reading json file" << std::endl;
     std::ifstream in("/spiffs/settings.json");
-    std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    std::string contents((std::istreambuf_iterator<char>(in)), 
+    std::istreambuf_iterator<char>());
 
     Puara::read_settings_json_internal(contents);
     fclose(f);

--- a/puara.cpp
+++ b/puara.cpp
@@ -1223,7 +1223,7 @@ void Puara::interpret_serial(void *pvParameters) {
         } else if (serial_data_str.compare("ping") == 0) {
             std::cout << "pong\n";
         } else if (serial_data_str.compare("whatareyou") == 0) {
-            std::cout << Puara::device << std::endl;
+            std::cout << Puara::data_start << Puara::dmiName << Puara::data_end << std::endl;
         } else if (serial_data_str.rfind("sendconfig", 0) == 0) {
             serial_data_str_buffer = serial_data_str.substr(serial_data_str.find(" ")+1);
             Puara::read_config_json_internal(serial_data_str_buffer);

--- a/puara.cpp
+++ b/puara.cpp
@@ -1213,9 +1213,8 @@ void Puara::interpret_serial(void *pvParameters) {
              serial_data_str.compare("reboot") == 0 ) {
             std::cout <<  "\nRebooting...\n" << std::endl;
             xTaskCreate(&Puara::reboot_with_delay, "reboot_with_delay", 1024, NULL, 10, NULL);
-        } else if (serial_data_str.rfind("getstrsetting", 0) == 0) {
-            std::string var_name = serial_data_str.substr(serial_data_str.find(" ")+1);
-            std::cout << Puara::getVarText(var_name) << std::endl;
+        } else if (serial_data_str.compare("whatareyou") == 0) {
+            std::cout << Puara::device << std::endl;
         } else if (serial_data_str.rfind("config", 0) == 0) {
             serial_data_str_buffer = serial_data_str.substr(serial_data_str.find(" ")+1);
             Puara::read_config_json_internal(serial_data_str_buffer);
@@ -1224,6 +1223,18 @@ void Puara::interpret_serial(void *pvParameters) {
             serial_data_str_buffer = serial_data_str.substr(serial_data_str.find(" ")+1);
             Puara::read_settings_json_internal(serial_data_str_buffer);
             Puara::write_settings_json();
+        } else if (serial_data_str.compare("getconfig") == 0) {
+            Puara::mount_spiffs();
+            FILE* f = fopen("/spiffs/config.json", "r");
+            if (f == NULL) {
+                std::cout << "json: Failed to open file" << std::endl;
+                return;
+            }
+            std::ifstream in("/spiffs/config.json");
+            std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+            std::cout << contents << std::endl;
+            fclose(f);
+            Puara::unmount_spiffs();
         } else {
             std::cout << "\nI don´t recognize the command \"" << serial_data_str << "\""<< std::endl;
         }

--- a/puara.cpp
+++ b/puara.cpp
@@ -1217,6 +1217,8 @@ void Puara::interpret_serial(void *pvParameters) {
              serial_data_str.compare("reboot") == 0 ) {
             std::cout <<  "\nRebooting...\n" << std::endl;
             xTaskCreate(&Puara::reboot_with_delay, "reboot_with_delay", 1024, NULL, 10, NULL);
+        } else if (serial_data_str.compare("ping") == 0) {
+            std::cout << "pong\n";
         } else if (serial_data_str.compare("whatareyou") == 0) {
             std::cout << Puara::device << std::endl;
         } else if (serial_data_str.rfind("sendconfig", 0) == 0) {

--- a/puara.h
+++ b/puara.h
@@ -48,7 +48,6 @@ class Puara {
     private:
         static unsigned int version;
         static std::string dmiName;
-
         struct settingsVariables {
             std::string name;
             std::string type;
@@ -100,6 +99,9 @@ class Puara {
         static void ap_event_handler(void* arg, esp_event_base_t event_base, int event_id, void* event_data);
         static void wifi_init();
 
+        static void read_settings_json_internal(std::string& contents);
+        static bool IsInConfigurationMode;
+
         static httpd_handle_t webserver;
         static httpd_config_t webserver_config;
         static httpd_uri_t index;
@@ -128,9 +130,10 @@ class Puara {
         static const uint8_t spiffs_max_files = 10;
         static const bool spiffs_format_if_mount_failed = false;
 
-        static char serial_data[12];
+        static char serial_data[128];
         static int serial_data_length;
         static std::string serial_data_str;
+        static std::string serial_config_str;
         static std::string convertToString(char* a);
         static void interpret_serial(void *pvParameter);
         static void serial_monitor(void *pvParameters);

--- a/puara.h
+++ b/puara.h
@@ -46,13 +46,11 @@
 #include <soc/uart_struct.h>
 
 class Puara {
-
     
     private:
         static unsigned int version;
         static std::string dmiName;
         
-
         struct settingsVariables {
             std::string name;
             std::string type;

--- a/puara.h
+++ b/puara.h
@@ -174,6 +174,7 @@ class Puara {
         static void read_settings_json();
         static void write_settings_json();
         static bool start_serial_listening();
+        static void send_serial_data(std::string data);
         static void start_mdns_service(const char * device_name, const char * instance_name);
         static void start_mdns_service(std::string device_name, std::string instance_name);
         static void wifi_scan(void);

--- a/puara.h
+++ b/puara.h
@@ -48,6 +48,7 @@ class Puara {
     private:
         static unsigned int version;
         static std::string dmiName;
+
         struct settingsVariables {
             std::string name;
             std::string type;

--- a/puara.h
+++ b/puara.h
@@ -50,7 +50,7 @@ class Puara {
     private:
         static unsigned int version;
         static std::string dmiName;
-        
+
         struct settingsVariables {
             std::string name;
             std::string type;

--- a/puara.h
+++ b/puara.h
@@ -8,6 +8,8 @@
 #ifndef PUARA_H
 #define PUARA_H
 
+#define PUARA_SERIAL_BUFSIZE 1024
+
 #include <stdio.h>
 #include <string>
 #include <cstring>
@@ -44,10 +46,12 @@
 #include <soc/uart_struct.h>
 
 class Puara {
+
     
     private:
         static unsigned int version;
         static std::string dmiName;
+        
 
         struct settingsVariables {
             std::string name;
@@ -100,8 +104,9 @@ class Puara {
         static void ap_event_handler(void* arg, esp_event_base_t event_base, int event_id, void* event_data);
         static void wifi_init();
 
+        static std::string serial_data_str_buffer;
         static void read_settings_json_internal(std::string& contents);
-        static bool IsInConfigurationMode;
+        static void read_config_json_internal(std::string& contents);
 
         static httpd_handle_t webserver;
         static httpd_config_t webserver_config;
@@ -131,12 +136,12 @@ class Puara {
         static const uint8_t spiffs_max_files = 10;
         static const bool spiffs_format_if_mount_failed = false;
 
-        static char serial_data[128];
+        static char serial_data[PUARA_SERIAL_BUFSIZE];
         static int serial_data_length;
         static std::string serial_data_str;
         static std::string serial_config_str;
         static std::string convertToString(char* a);
-        static void interpret_serial(void *pvParameter);
+        static void interpret_serial(void *pvParameters);
         static void serial_monitor(void *pvParameters);
         static const int reboot_delay = 3000;
         static void reboot_with_delay(void *pvParameter);

--- a/puara.h
+++ b/puara.h
@@ -167,6 +167,8 @@ class Puara {
         static std::string getLocalPORTStr();
         static void mount_spiffs();
         static void unmount_spiffs();
+        static const std::string data_start;
+        static const std::string data_end;
         static void read_config_json();
         static void write_config_json();
         static void read_settings_json();

--- a/puara.h
+++ b/puara.h
@@ -105,8 +105,9 @@ class Puara {
         static void wifi_init();
 
         static std::string serial_data_str_buffer;
-        static void read_settings_json_internal(std::string& contents);
+        static void read_settings_json_internal(std::string& contents, bool merge=false);
         static void read_config_json_internal(std::string& contents);
+        static void merge_settings_json(std::string& new_contents);
 
         static httpd_handle_t webserver;
         static httpd_config_t webserver_config;


### PR DESCRIPTION
This works in conjunction with the Puara Serial Manager (https://github.com/IDMIL/T-Tree/blob/master/client/puara_serial_manager.py) to send and receive settings via the serial port.