### PR TITLE
Replace external ap ip log with unconditional print

### DIFF
--- a/src/puara_wifi.cpp
+++ b/src/puara_wifi.cpp
@@ -270,8 +270,7 @@ void WiFi::sta_event_handler(
     tempBuf << esp_ip4_addr3_16(&event->ip_info.ip) << ".";
     tempBuf << esp_ip4_addr4_16(&event->ip_info.ip);
     self.currentSTA_IP = tempBuf.str();
-    LOG("wifi/sta_event_handler: got ip:");
-    LOG(self.currentSTA_IP);
+    std::cout << "Connected to external AP With ip " << self.currentSTA_IP  << std::endl;
     self.connect_counter = 0;
     xEventGroupSetBits(self.s_wifi_event_group, self.wifi_connected_bit);
   }
@@ -281,4 +280,4 @@ bool WiFi::get_StaIsConnected()
 {
   return StaIsConnected;
 }
-} 
+}


### PR DESCRIPTION
Now that logging is disabled by default, puara-module didn't print its external AP IP by default. This makes it so puara-module will always print the IP it got from an external access point, making it a bit friendlier. 