### PR TITLE
57 remove all arduino related ci and examples from current repo

### DIFF
--- a/.github/workflows/arduino.yml
+++ b/.github/workflows/arduino.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - 57-remove-all-arduino-related-ci-and-examples-from-current-repo
     tags:
       - v*
 


### PR DESCRIPTION
updated CI to do : 
step 1 : update puara-arduino 
step 2 : certify that lib is arduino compatible
step 3 : test  examples in puara arduino that were copied from puara module templates (only two are being tested right now as we need to determine how to include complicated lib dependencies in arduino projects/CI)