### PR TITLE
Properly put default values in the httpd configs

### DIFF
--- a/src/puara_web.hpp
+++ b/src/puara_web.hpp
@@ -54,7 +54,7 @@ struct Webserver
   std::string APpasswdVal2;
 
   httpd_handle_t webserver;
-  httpd_config_t webserver_config;
+  httpd_config_t webserver_config = HTTPD_DEFAULT_CONFIG();
 
   // FIXME frozen::hash_map
   std::unordered_map<std::string, int> config_fields


### PR DESCRIPTION
This fixes the http server startup on recent ESP-IDF/esp32-arduino versions.