### PR TITLE
delete library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,0 @@
-name=puara-module
-version=1.0.0
-author=Edu_Meneses
-maintainer=Edu <emeneses@sat.qc.ca>, SAT <innovation@sat.qc.ca>
-sentence=esp32 DMI helpers
-paragraph=This library provides helper modules for ESP32-based music controllers using the Puara framework. It includes a Wi-Fi manager for easy network setup, an OSC manager for Open Sound Control messaging, and compatibility with libmapper for device mapping. Designed to simplify development of digital musical instruments and controllers.
-category=Device Control
-url=https://github.com/Puara/puara-module
-architectures=*


### PR DESCRIPTION
Closes #107 

Following the https://github.com/Puara/puara-gestures/pull/59#pullrequestreview-3948971516, the actual library.properties lives on [puara-arduino](https://github.com/Puara/puara-arduino). The library.properties in this repo is redundant (and outdated).

Let's remove it.